### PR TITLE
fix(deploy/build/Dockerfile): fix builder version problem

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 AS builder
+FROM golang:1.16 AS builder
 
 ARG APP_RELATIVE_PATH
 


### PR DESCRIPTION
There are no os.ReadDir and io.ReadAll function in go1.15. Upgrade to go1.16 could fix it.